### PR TITLE
Update PhqlQueryParser.php

### DIFF
--- a/src/PhalconRest/QueryParsers/PhqlQueryParser.php
+++ b/src/PhalconRest/QueryParsers/PhqlQueryParser.php
@@ -78,7 +78,7 @@ class PhqlQueryParser extends Plugin
                 }
             }
 
-            $allConditions = $orConditions + $andConditions;
+            $allConditions = array_merge($orConditions, $andConditions);
 
             /** @var Condition $condition */
             foreach ($allConditions as $conditionIndex => $condition) {


### PR DESCRIPTION
$andConditions and $orConditions have numeric keys. But for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored.
May be it is better to use array_merge?